### PR TITLE
Update Intercom gem to support Acquire package

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    intercom-rails (0.2.27)
+    intercom-rails (0.2.28)
       activesupport (> 3.0)
 
 GEM

--- a/README.mdown
+++ b/README.mdown
@@ -39,6 +39,7 @@ If it's not working make sure:
 * You've generated a config file with your `app_id` as detailed above.
 * Your user object responds to an `id` or `email` method.
 * Your current user is accessible in your controllers as `current_user` or `@user`, if not in `config/initializers/intercom.rb`:
+* If you want the Intercom Messenger to be available when there is no current user,  set `config.include_for_logged_out_users = true` in your config and sign up for the [Acquire](https://www.intercom.io/live-chat) package.
 
 ```ruby
   config.user.current = Proc.new { current_user_object }
@@ -113,6 +114,13 @@ config.company.custom_data = {
   :number_of_messages => Proc.new { |app| app.messages.count },
   :is_interesting => :is_interesting?
 }
+```
+
+### Live Chat / Acquire
+With our [Acquire package](https://www.intercom.io/live-chat), Intercom Messenger now works with logged out users and visitors to your web site. Include the Intercom snippet on every page by setting:
+
+```ruby
+  config.include_for_logged_out_users = true
 ```
 
 ### Messenger

--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -54,7 +54,11 @@ module IntercomRails
       end
 
       def intercom_script_tag
-        @script_tag ||= ScriptTag.new(:find_current_user_details => true, :find_current_company_details => true, :controller => controller)
+        @script_tag ||= ScriptTag.new(:find_current_user_details => true, :find_current_company_details => true, :controller => controller, :show_everywhere => show_everywhere?)
+      end
+
+      def show_everywhere?
+        IntercomRails.config.include_for_logged_out_users
       end
 
       def enabled_for_environment?

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -84,6 +84,7 @@ module IntercomRails
     config_accessor :api_key
     config_accessor :library_url
     config_accessor :enabled_environments, &ARRAY_VALIDATOR
+    config_accessor :include_for_logged_out_users
 
     config_group :user do
       config_accessor :current, &IS_PROC_VALIDATOR

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -10,13 +10,14 @@ module IntercomRails
       new(*args).output
     end
 
-    attr_reader :user_details, :company_details
+    attr_reader :user_details, :company_details, :show_everywhere
     attr_accessor :secret, :widget_options, :controller
 
     def initialize(options = {})
       self.secret = options[:secret] || Config.api_secret
       self.widget_options = widget_options_from_config.merge(options[:widget] || {})
       self.controller = options[:controller]
+      @show_everywhere = options[:show_everywhere]
       self.user_details = options[:find_current_user_details] ? find_current_user_details : options[:user_details]
       self.company_details = if options[:find_current_company_details]
         find_current_company_details
@@ -26,7 +27,11 @@ module IntercomRails
     end
 
     def valid?
-      user_details[:app_id].present? && (user_details[:user_id] || user_details[:email]).present?
+      valid = user_details[:app_id].present?
+      unless @show_everywhere
+        valid = valid && (user_details[:user_id] || user_details[:email]).present?
+      end
+      valid
     end
 
     def intercom_settings

--- a/lib/intercom-rails/version.rb
+++ b/lib/intercom-rails/version.rb
@@ -1,3 +1,3 @@
 module IntercomRails
-  VERSION = "0.2.27"
+  VERSION = "0.2.28"
 end

--- a/lib/rails/generators/intercom/config/config_generator.rb
+++ b/lib/rails/generators/intercom/config/config_generator.rb
@@ -15,6 +15,7 @@ module Intercom
         @app_id = app_id
         @api_secret = api_secret
         @api_key = api_key
+        @include_for_logged_out_users = false
 
         introduction = <<-desc
 Intercom will automatically insert its javascript before the closing '</body>'

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -38,6 +38,15 @@ IntercomRails.config do |config|
   # config.user.current = Proc.new { current_user }
   <%- end -%>
 
+  # == Include for logged out Users
+  # If set to true, include the Intercom messenger on all pages, regardless of whether
+  # The user model class (set below) is present. Only available for Apps on the Acquire plan.
+  <%- if @include_for_logged_out_users -%>
+  config.include_for_logged_out_users = true
+  <%- else -%>
+  # config.include_for_logged_out_users = true
+  <%- end -%>
+
   # == User model class
   # The class which defines your user model
   #

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -115,4 +115,16 @@ describe IntercomRails::ScriptTag do
       expect(script_tag.intercom_settings[:company]).to eq({'id' => '6', 'name' => 'Intercom'})
     end
   end
+
+  context 'without user details' do
+    it 'should be valid when show_everywhere is set' do
+      script_tag = ScriptTag.new(:show_everywhere => true)
+      expect(script_tag.valid?).to eq(true)
+    end
+
+    it 'should not be valid when show_everywhere is not set' do
+      script_tag = ScriptTag.new()
+      expect(script_tag.valid?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
There is a new version of the intercom-rails gem out that supports the new 'Acquire' package. 

This enables the chatbox to be available for user's who aren't logged in. 

Trello card: https://trello.com/c/YgUlh86m/833-add-intercom-acquire-snippet-sitewide

After we update we need to add this to intercom.rb in ImageBrief

`config.include_for_logged_out_users = true`
